### PR TITLE
Add Submodule for Private Repository Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "private"]
+	path = private
+	url = https://github.com/robellegate/test-repo-private


### PR DESCRIPTION
This PR introduces a Git submodule for integrating a private repository into the current public repository. The purpose of this change is to test and demonstrate the feasibility of such integrations, ensuring secure and functional access while maintaining a modular project structure. This approach can streamline workflows where private resources are essential for public project functionality.

### Changes:

- Add Git submodule for private repository integration (31cb743)
  - Introduced a Git submodule to reference a private repository, allowing modular project design.
  - Tested the submodule setup to ensure compatibility and secure integration in a public repository context.